### PR TITLE
Add ChainSafe js-libp2p maintainers as members

### DIFF
--- a/github/multiformats/membership.json
+++ b/github/multiformats/membership.json
@@ -188,6 +188,9 @@
   "momack2": {
     "role": "member"
   },
+  "mpetrunic": {
+    "role": "member"
+  },
   "mxinden": {
     "role": "member"
   },
@@ -258,6 +261,9 @@
     "role": "member"
   },
   "web3-bot": {
+    "role": "member"
+  },
+  "wemeetagain": {
     "role": "member"
   },
   "whyrusleeping": {


### PR DESCRIPTION
@mpetrunic and I are helping maintain js-libp2p and there is overlap between the libraries under the libp2p org and this one.
We'd like to be able to give code reviews and help maintain the js libraries here.

We don't need any special permissions, so I didn't go thru the trouble of adding a special team as was done here:
https://github.com/libp2p/github-mgmt/pull/7

cc @biglep