### PR TITLE
add Jorropo to w3dt-stewards

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -59,6 +59,7 @@ members:
     - jacobheun
     - jbenetsafer
     - jesseclay
+    - Jorropo
     - kevina
     - kumavis
     - lidel
@@ -1528,6 +1529,7 @@ teams:
         - MarcoPolo
         - achingbrain
         - galargh
+        - Jorropo
         - lidel
         - mxinden
     privacy: closed


### PR DESCRIPTION
I'm reviewing contributor work to add blake3 support to Kubo and need perms to merge go-multiformats work about variable lengthen functions.