### PR TITLE
Lock down multicodec table.csv until there is governance for it

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1032,9 +1032,6 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
-      push:
-        - Go Team
-        - JavaScript Team
     visibility: public
   multiformats:
     collaborators:


### PR DESCRIPTION
### Summary

At the 2022-11-10 [IPFS Implementers Sync](https://www.notion.so/pl-strflt/IPFS-Implementers-Sync-2022-11-10-fefb941ec00b4211ba71ca571a0ec883), the decision was made to lock the multicodec `table.csv` until we design some governance for it.

This change removes push access from the Go and JS Teams.

### Why do you need this?

We are working towards standardising multi* and that includes standardising a registry from that table. We need to avoid the proliferation of registrations, and ideally carry out some amount of cleanup, and build up governance for it. The first step is to lock it down. Admins can still make changes if absolutely necessary.

### What else do we need to know?

This is my first change here, so it may be wrong, and I am new to the community which means I may be committing a woefully inappropriate faux-pas. #YOLO

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
