### PR TITLE
chore: add chainsafe libp2p maintainers in Javascript Team

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1632,12 +1632,14 @@ teams:
         - lidel
         - litzenberger
         - mcollina
+        - mpetrunic
         - momack2
         - olizilla
         - pkafei
         - richardschneider
         - vasco-santos
         - wanderer
+        - wemeetagain
     privacy: closed
   Parity Tech:
     members:

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1632,8 +1632,8 @@ teams:
         - lidel
         - litzenberger
         - mcollina
-        - mpetrunic
         - momack2
+        - mpetrunic
         - olizilla
         - pkafei
         - richardschneider


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
Seems like in https://github.com/multiformats/github-mgmt/pull/29 we forgot to add ourselves to Javascript Team.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
So we can maintain js-multiaddr and other  js related repositories

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
