### PR TITLE
feat: add ipfs-gui team

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -52,8 +52,8 @@ members:
     - jacobheun
     - jbenetsafer
     - jesseclay
-    - juliaxbow
     - Jorropo
+    - juliaxbow
     - kevina
     - kumavis
     - lidel
@@ -177,8 +177,8 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - w3dt-stewards
         - ipfs-gui
+        - w3dt-stewards
       pull:
         - ci
         - JavaScript Team
@@ -1589,20 +1589,6 @@ teams:
       member:
         - lukehoersten
     privacy: closed
-  ipfs-gui:
-    description: IPFS GUI Team
-    members:
-      maintainer:
-        - lidel
-        - SgtPooki
-        - tinytb
-      member:
-        - djmcquillan
-        - juliaxbow
-        - lidel
-        - SgtPooki
-        - whizzzkid
-    privacy: closed
   Infra:
     description: https://github.com/protocol/infra-team/
     privacy: closed
@@ -1618,6 +1604,20 @@ teams:
       maintainer:
         - galargh
     parent_team_id: w3dt-stewards
+    privacy: closed
+  ipfs-gui:
+    description: IPFS GUI Team
+    members:
+      maintainer:
+        - lidel
+        - SgtPooki
+        - tinytb
+      member:
+        - djmcquillan
+        - juliaxbow
+        - lidel
+        - SgtPooki
+        - whizzzkid
     privacy: closed
   Java Team:
     description: Java Java Java Java Java ☕️

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -32,6 +32,7 @@ members:
     - dhruvbaldawa
     - dignifiedquire
     - djdv
+    - djmcquillan
     - dryajov
     - ekroon
     - elenaf9
@@ -51,6 +52,7 @@ members:
     - jacobheun
     - jbenetsafer
     - jesseclay
+    - juliaxbow
     - Jorropo
     - kevina
     - kumavis
@@ -79,7 +81,9 @@ members:
     - robzajac
     - rphmeier
     - sbuss
+    - SgtPooki
     - stuckinaboot
+    - tinytb
     - TKorr
     - tomaka
     - travisperson
@@ -91,6 +95,7 @@ members:
     - warpfork
     - web3-bot
     - wemeetagain
+    - whizzzkid
     - willscott
     - yusefnapora
     - zabirauf
@@ -173,6 +178,7 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+        - ipfs-gui
       pull:
         - ci
         - JavaScript Team
@@ -1583,6 +1589,20 @@ teams:
       member:
         - lukehoersten
     privacy: closed
+  ipfs-gui:
+    description: IPFS GUI Team
+    members:
+      maintainer:
+        - lidel
+        - SgtPooki
+        - tinytb
+      member:
+        - djmcquillan
+        - juliaxbow
+        - lidel
+        - SgtPooki
+        - whizzzkid
+    privacy: closed
   Infra:
     description: https://github.com/protocol/infra-team/
     privacy: closed
@@ -1723,9 +1743,12 @@ teams:
         - Stebalien
       member:
         - achingbrain
+        - djmcquillan
         - galargh
         - Jorropo
         - lidel
         - MarcoPolo
         - mxinden
+        - SgtPooki
+        - whizzzkid
     privacy: closed

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1615,8 +1615,6 @@ teams:
       member:
         - djmcquillan
         - juliaxbow
-        - lidel
-        - SgtPooki
         - whizzzkid
     privacy: closed
   Java Team:


### PR DESCRIPTION
### Summary
1. add ipfs-gui team to the org (add all members to the org)
2. Add ipfs-gui team as admin for cid-utils-website

### Why do you need this?
We need to be able to maintain the project since ipfs-gui team owns it.

### What else do we need to know?
IPFS GUI team owns cid-utils-website

**DRI:** @SgtPooki
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
