### PR TITLE
Add back broad push access to multicodec

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1080,6 +1080,9 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+      push:
+        - Go Team
+        - JavaScript Team
     visibility: public
   multiformats:
     collaborators:


### PR DESCRIPTION
Ref: https://github.com/multiformats/github-mgmt/pull/53

I think this gets us back to where we were but with the new much stricter master protection.