### PR TITLE
Reduce org owners/admins

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -549,7 +549,6 @@ repositories:
           contexts:
             - Comment
           strict: true
-    collaborators:
     default_branch: master
     files:
       CODEOWNERS:

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1,20 +1,25 @@
 # yaml-language-server: $schema=.schema.json
 
 members:
+  # Admin permissions map to "org owner" permissions listed in 
+  # https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-rolesare 
+  # These permissions are very broad, and thus, the list of people is intentionally minimal. 
+  # Permissions are distributed across 3-4 separate organizations.
+  # One can request additional permissions for specific repos using ipld/github-mgmt.
   admin:
     - andyschwab-admin
     - aschmahmann
-    - daviddias
     - galargh
+    - rvagg
+    - vmx
+  member:
+    - daviddias
     - jbenet
     - Kubuxu
     - marten-seemann
     - raulk
-    - rvagg
     - Stebalien
-    - vmx
     - whyrusleeping
-  member:
     - 0xDanomite
     - 2color
     - aarshkshah1992

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -550,8 +550,6 @@ repositories:
             - Comment
           strict: true
     collaborators:
-      admin:
-        - galargh
     default_branch: master
     files:
       CODEOWNERS:
@@ -2511,18 +2509,19 @@ teams:
     #  using a team instead of direct collaborators because we want to reference it in the CODEOWNERS file
     description: Users that are effectively org admins
     members:
-      # WARN: membership here should be treated exactly as cautiosly as having an org admin role
+      # WARN: membership here should be treated as cautiously as having an "org owner" role,
+      # since one can escalate their privileges accordingly.
       # ATTN: members are expected to:
       #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
-      maintainer:
+      # Intentionally don't have any "maintainers" so that additional membership is done through github-mgmt rather than the GitHub UI.
+      # That said, since most of these people are also "org owners" ("members.admin" above), 
+      # they can still make changes in the UI.
+      member:
         - achingbrain
         - aschmahmann
         - rvagg
         - vmx
-      member:
-        - BigLep
-        - lidel
     privacy: closed
   Go Team:
     description: Go multiformats people

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -13,13 +13,6 @@ members:
     - rvagg
     - vmx
   member:
-    - daviddias
-    - jbenet
-    - Kubuxu
-    - marten-seemann
-    - raulk
-    - Stebalien
-    - whyrusleeping
     - 0xDanomite
     - 2color
     - aarshkshah1992
@@ -34,6 +27,7 @@ members:
     - bigs
     - celeduc
     - cloutiertyler
+    - daviddias
     - debris
     - dhruvbaldawa
     - dignifiedquire
@@ -56,10 +50,12 @@ members:
     - ianopolous
     - ipfsbot
     - jacobheun
+    - jbenet
     - jbenetsafer
     - jesseclay
     - Jorropo
     - kevina
+    - Kubuxu
     - kumavis
     - laurentsenta
     - lidel
@@ -68,6 +64,7 @@ members:
     - lukehoersten
     - magik6k
     - MarcoPolo
+    - marten-seemann
     - masih
     - MCGPPeters
     - mcollina
@@ -82,6 +79,7 @@ members:
     - olizilla
     - p-shahi
     - pkafei
+    - raulk
     - ribasushi
     - RichardLitt
     - richardschneider
@@ -89,6 +87,7 @@ members:
     - rphmeier
     - sbuss
     - SgtPooki
+    - Stebalien
     - stuckinaboot
     - sukunrt
     - thomaseizinger
@@ -104,6 +103,7 @@ members:
     - web3-bot
     - wemeetagain
     - whizzzkid
+    - whyrusleeping
     - willscott
     - yusefnapora
     - zabirauf


### PR DESCRIPTION
### Summary
This aligns with the "reduce org owners" step listed in https://github.com/ipfs/ipfs/issues/511.

This is the first step of wider 2024Q1 permissions cleanup.

This is matching IPLD for now: https://github.com/ipld/github-mgmt/pull/68

### Why do you need this?
Github org safety.  See https://github.com/ipfs/ipfs/issues/511 for more info.

### Timeline
- [x] 2024-02-12: public PR
- [x] 2024-02-12: notify affected parties: https://github.com/multiformats/github-mgmt/pull/85#issuecomment-1940098750
- [ ] 2024-02-14: merge this change assuming no major pushback

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request