### PR TITLE
Handle github-mgmt stewards portion of reduce org owners/admins

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -550,8 +550,6 @@ repositories:
             - Comment
           strict: true
     collaborators:
-      admin:
-        - galargh
     default_branch: master
     files:
       CODEOWNERS:
@@ -2511,18 +2509,19 @@ teams:
     #  using a team instead of direct collaborators because we want to reference it in the CODEOWNERS file
     description: Users that are effectively org admins
     members:
-      # WARN: membership here should be treated exactly as cautiosly as having an org admin role
+      # WARN: membership here should be treated as cautiously as having an "org owner" role,
+      # since one can escalate their privileges accordingly.
       # ATTN: members are expected to:
       #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
-      maintainer:
+      # Intentionally don't have any "maintainers" so that additional membership is done through github-mgmt rather than the GitHub UI.
+      # That said, since most of these people are also "org owners" ("members.admin" above), 
+      # they can still make changes in the UI.
+      member:
         - achingbrain
         - aschmahmann
         - rvagg
         - vmx
-      member:
-        - BigLep
-        - lidel
     privacy: closed
   Go Team:
     description: Go multiformats people


### PR DESCRIPTION
I didn't mean to create this PR.  I meant to make the commits directly into biglep-reduce-org-owners-2024q1 as part of https://github.com/multiformats/github-mgmt/pull/85.  I'll merge it so can discuss more in biglep-reduce-org-owners-2024q1