### PR TITLE
Reduce org owners further

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -3,15 +3,21 @@
 members:
   # Admin permissions map to "org owner" permissions listed in 
   # https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-rolesare 
-  # These permissions are very broad, and thus, the list of people is intentionally minimal. 
-  # Permissions are distributed across 3-4 separate organizations.
-  # One can request additional permissions for specific repos using ipld/github-mgmt.
+  # These permissions are very broad, and thus the list of people is intentionally minimal.
+  # Day-to-day administrating is done by those in the "github-mgmt Stewards" team (see team below).  
+  # "github-mgmt Stewards" team can still escalate into org owner permissions if/when needed.  
+  # This minimal owner set plus supporting rationale was documented and discussed in https://github.com/ipfs/ipfs/issues/511 .
   admin:
+    # Why @andyschwab-admin?
+    # 1. leader of [Sodal](https://sodal.io/)
+    # 2. has close access to [sead](https://www.sead.ai/), which is charged with sysadmin for critical systems within the wider Protocol Labs Network
+    # 3. general long-standing sysadmin for these organizations with his past roles at PL Inc
+    # 4. This isn't andyschwab's day-to-day GitHub account
     - andyschwab-admin
-    - aschmahmann
+    # Why @galargh?
+    # 1. co-founder of [IPDX](https://ipdx.co), and IPDX is contracted to look after GitHub for this organization.
+    # 2. Multiple years of experience managing GitHub organizations of open source projects, including this org.
     - galargh
-    - rvagg
-    - vmx
   member:
     - 0xDanomite
     - 2color
@@ -23,6 +29,7 @@ members:
     - amstocker
     - andyschwab
     - arkpar
+    - aschmahmann
     - BigLep
     - bigs
     - celeduc
@@ -85,6 +92,7 @@ members:
     - richardschneider
     - robzajac
     - rphmeier
+    - rvagg
     - sbuss
     - SgtPooki
     - Stebalien
@@ -97,6 +105,7 @@ members:
     - travisperson
     - vasco-santos
     - victorb
+    - vmx
     - vyzo
     - wanderer
     - warpfork
@@ -2504,8 +2513,14 @@ teams:
         - zabirauf
     privacy: closed
   github-mgmt stewards:
-    # NOTE: created to capture users with push+ access to github-mgmt repository
-    #  using a team instead of direct collaborators because we want to reference it in the CODEOWNERS file
+    # Notes: 
+    # 1. These members have push+ access to the github-mgmt repository (in addition to the ipdx team and the org owners listed in "members.admin" above).
+    # 2. This team also has the org-level "moderator" and "security manager" role.
+    #    This is configured through the GitHub UI, not in GitHub management.
+    #    (Org-level role documentation: https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization)
+    # 3. Having a team instead of direct collaborators on the github-mgmt repository also enables easy reference in the github-mgmt CODEOWNERS file.
+    # 4. Leaning on "github-mgmt stewards" for day-to-day admin over true org owners was done
+    #    as part of the effort to reduce org owners in https://github.com/ipfs/ipfs/issues/511
     description: Users that are effectively org admins
     members:
       # WARN: membership here should be treated as cautiously as having an "org owner" role,
@@ -2513,13 +2528,24 @@ teams:
       # ATTN: members are expected to:
       #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
-      # Intentionally don't have any "maintainers" so that additional membership is done through github-mgmt rather than the GitHub UI.
-      # That said, since most of these people are also "org owners" ("members.admin" above), 
-      # they can still make changes in the UI.
+      # INFO: Intentionally don't have any "maintainers" so that additional membership is done through github-mgmt rather than the GitHub UI.
+      # INFO: There are others who could certainly qualify to be members of this team.  
+      # There is a balance to be had to ensure there are enough knowledgeable people available to support the needs/requests of the github org,
+      # and reducing risk by not having too many with the escalation path that this role affords.
       member:
+        # Why @achingbrain?
+        # 1. libp2p is a key stakeholer of some of the multiformats repos (e.g., multiaddr).  @achingbrain helps represent that community (and the JS IPFS side as well).
+        # 2. Active maintainer of JS repos in the org.
         - achingbrain
+        # Why @aschmahmann?
+        # 1. Long-time and still very active contributor to important Go-based IPFS repos that consume and occasionally require changes of multiformats repos. 
+        # 2. Director of IP Shipyard, which is an organization receiving significant grant funding for "IPFS development and maintenance", which includes multiformats as needed.
         - aschmahmann
+        # Why @rvagg?
+        # 1. Continued Multiformats maintainer since the pre-2021 days of an "IPLD core team".
         - rvagg
+        # Why @vmx?
+        # 1. Continued Multiformats maintainer since the pre-2021 days of an "IPLD core team".
         - vmx
     privacy: closed
   Go Team:


### PR DESCRIPTION
### Summary
Followup to https://github.com/multiformats/github-mgmt/pull/85 to further reduce org owners/admins based on where have been landing in https://github.com/ipfs/ipfs/issues/511.  This is the multiformats corollary of https://github.com/ipld/github-mgmt/pull/69.

No worries if Multiformats doesn't want to go to this extreme - this can be abandoned.  

If this approved, after merging, the following steps will need to be taken:
- [x] @galargh give "github-mgmt stewards" team "[moderator](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-moderators)" and "[security manager](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#security-managers)" roles

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
