### PR TITLE
fix: allow Rust Team to push to rust-cid

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1973,6 +1973,7 @@ teams:
         - mxinden
         - rphmeier
         - thomaseizinger
+        - Stebalien
         - tomaka
         - vmx
     privacy: closed

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1972,8 +1972,8 @@ teams:
         - mriise
         - mxinden
         - rphmeier
-        - thomaseizinger
         - Stebalien
+        - thomaseizinger
         - tomaka
         - vmx
     privacy: closed

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1439,6 +1439,7 @@ repositories:
       pull:
         - Admin
         - github-mgmt stewards
+      push:
         - Rust Team
     topics:
       - cid


### PR DESCRIPTION
### Summary

On the other Rust related has the Rust Team push access, so add it to rust-cid as well.

### Why do you need this?

To restore my own push access.


### What else do we need to know?

It might make sense to review the members of the Rust Team, it can likely be trimmed down. But that's a separate issue.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
