### PR TITLE
adding jxs to Rust team

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -61,6 +61,7 @@ members:
     - jbenetsafer
     - jesseclay
     - Jorropo
+    - jxs
     - kevina
     - Kubuxu
     - kumavis
@@ -1897,6 +1898,7 @@ teams:
         - dignifiedquire
         - elenaf9
         - Gozala
+        - jxs
         - mriise
         - mxinden
         - Stebalien


### PR DESCRIPTION
### Summary

Adding @jxs to the Rust team

### Why do you need this?

@jxs is maintainer of [rust-libp2p](https://github.com/libp2p/rust-libp2p) and needs access to multiformats

### What else do we need to know?

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
