### PR TITLE
add ipfs-tech org to key mf repos

### DIFF
--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1182,8 +1182,8 @@ repositories:
         - github-mgmt stewards
       push:
         - Go Team
-        - JavaScript Team
         - ipfs-tech
+        - JavaScript Team
     visibility: public
   multibase:
     advanced_security: false

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1180,10 +1180,10 @@ repositories:
         - w3dt-stewards
       pull:
         - github-mgmt stewards
-        - ipfs-tech
       push:
         - Go Team
         - JavaScript Team
+        - ipfs-tech
     visibility: public
   multibase:
     advanced_security: false
@@ -1851,6 +1851,12 @@ teams:
         - lidel
         - SgtPooki
     privacy: closed
+  ipfs-tech:
+    description: IPFS Foundation spec and registry maintenance crew
+      member:
+        - bumblefudge
+        - darobin
+        - mishmosh
   Java Team:
     description: Java Java Java Java Java ☕️
     members:

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1854,7 +1854,8 @@ teams:
     privacy: closed
   ipfs-tech:
     description: IPFS Foundation spec and registry maintenance crew
-      member:
+    members:
+      maintainer:
         - bumblefudge
         - darobin
         - mishmosh

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1203,8 +1203,8 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - w3dt-stewards
         - ipfs-tech
+        - w3dt-stewards
       pull:
         - github-mgmt stewards
       push:
@@ -1253,8 +1253,8 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - w3dt-stewards
         - ipfs-tech
+        - w3dt-stewards
       pull:
         - github-mgmt stewards
       push:
@@ -1279,8 +1279,8 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - w3dt-stewards
         - ipfs-tech
+        - w3dt-stewards
       pull:
         - Contributors
         - github-mgmt stewards
@@ -1631,8 +1631,8 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - w3dt-stewards
         - ipfs-tech
+        - w3dt-stewards
       pull:
         - github-mgmt stewards
         - Go Team
@@ -1688,8 +1688,8 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - w3dt-stewards
         - ipfs-tech
+        - w3dt-stewards
       pull:
         - github-mgmt stewards
       push:

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1203,12 +1203,12 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - ipfs-tech
         - w3dt-stewards
       pull:
         - github-mgmt stewards
       push:
         - Go Team
+        - ipfs-tech
         - JavaScript Team
     visibility: public
   multicodec:
@@ -1253,12 +1253,12 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - ipfs-tech
         - w3dt-stewards
       pull:
         - github-mgmt stewards
       push:
         - Go Team
+        - ipfs-tech
         - JavaScript Team
     visibility: public
   multiformats:
@@ -1279,13 +1279,13 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - ipfs-tech
         - w3dt-stewards
       pull:
         - Contributors
         - github-mgmt stewards
       push:
         - Go Team
+        - ipfs-tech
         - JavaScript Team
     visibility: public
   multigram:
@@ -1631,13 +1631,14 @@ repositories:
         - Admin
         - ip-productivity
         - ipdx
-        - ipfs-tech
         - w3dt-stewards
       pull:
         - github-mgmt stewards
         - Go Team
         - JavaScript Team
         - Rust Team
+      push:
+        - ipfs-tech
     visibility: public
   SwiftMultiaddr:
     archived: true

--- a/github/multiformats.yml
+++ b/github/multiformats.yml
@@ -1180,6 +1180,7 @@ repositories:
         - w3dt-stewards
       pull:
         - github-mgmt stewards
+        - ipfs-tech
       push:
         - Go Team
         - JavaScript Team
@@ -1203,6 +1204,7 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+        - ipfs-tech
       pull:
         - github-mgmt stewards
       push:
@@ -1252,6 +1254,7 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+        - ipfs-tech
       pull:
         - github-mgmt stewards
       push:
@@ -1277,6 +1280,7 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+        - ipfs-tech
       pull:
         - Contributors
         - github-mgmt stewards
@@ -1628,6 +1632,7 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+        - ipfs-tech
       pull:
         - github-mgmt stewards
         - Go Team
@@ -1684,6 +1689,7 @@ repositories:
         - ip-productivity
         - ipdx
         - w3dt-stewards
+        - ipfs-tech
       pull:
         - github-mgmt stewards
       push:


### PR DESCRIPTION
### Summary

Hey there-- as I've been leading the [recent IETF efforts for multiformats](https://mailarchive.ietf.org/arch/browse/multiformats/) and getting more involved in the general upkeep of docs and such, I never asked for privileges here, but [Rod asked me to do so](https://github.com/multiformats/website/pull/75#issuecomment-2440323861) and the timing seems good since the IPFS Foundation now officially exists. I'm asking for privileges for the Foundation org rather than for me personally just to simplify delegation and maintenance down the road.

### Why do you need this?

Just want to include multiformats/website in periodic documentation refreshes and have push-rights in multicodec if the IETF WG spins up in coming months.

### What else do we need to know?

**DRI:** myself, @mishmosh, @darobin (current members of the ipfs-tech org)

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
